### PR TITLE
BUGFIX: Load ExtJs files from root directory instead of vendor directory

### DIFF
--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -83,5 +83,11 @@
                 class="nlxShopEnvironment\Factory\ReflectionClassFactory"
         >
         </service>
+
+        <!-- Subscriber -->
+        <service id="nlx_shop_environment.subscriber.backendtheme" class="nlxShopEnvironment\Subscriber\BackendTheme">
+            <tag name="shopware.event_subscriber" />
+        </service>
+
     </services>
 </container>

--- a/Subscriber/BackendTheme.php
+++ b/Subscriber/BackendTheme.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Created by netlogix GmbH & Co. KG
+ *
+ * @copyright netlogix GmbH & Co. KG
+ */
+
+namespace nlxShopEnvironment\Subscriber;
+
+use Enlight\Event\SubscriberInterface;
+
+class BackendTheme implements SubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            // After \Shopware\Components\Theme\EventListener\BackendTheme with priority 2
+            'Enlight_Controller_Front_RouteShutdown' => ['registerBackendTheme', 10],
+        ];
+    }
+
+    public function registerBackendTheme(\Enlight_Controller_EventArgs $args)
+    {
+        if ($args->getRequest()->getModuleName() !== 'backend') {
+            return;
+        }
+
+        $template = Shopware()->Container()->get('template');
+        assert($template instanceof \Enlight_Template_Manager);
+        // By default shopware loads the engine files from the /vendor directory
+        // Try to resolve engine/Library files from root directory first
+        $template->addTemplateDir(Shopware()->DocPath() . 'engine/Library', 'engine_library', \Enlight_Template_Manager::POSITION_PREPEND);
+    }
+
+}


### PR DESCRIPTION
By default shopware in composer mode load files from vendor directory.
In my opinions not blocking requests to the vendor folder could lead
to a massive security risk.
You can read more about this in the blog post of Sebastian Bergmann
https://thephp.cc/articles/phpunit-a-security-risk