### PR TITLE
FEATURE: Allow fallback values for env variables

### DIFF
--- a/Services/Resolver/EnvironmentResolver.php
+++ b/Services/Resolver/EnvironmentResolver.php
@@ -43,10 +43,15 @@ class EnvironmentResolver implements Resolver
     private function getResolvedValue(string $value): string
     {
         \preg_match('/\(([^\)]*)\)/', $value, $matches);
-        $resolvedValue = \getenv($matches[1]);
+        $envName = $matches[1];
+        if (false !== \strpos($envName, ':-')) {
+            list($envName, $default) = \explode(':-', $matches[1], 2);
+        }
 
-        if (false === $resolvedValue) {
-            return '';
+        $resolvedValue = \getenv($envName);
+
+        if (empty($resolvedValue)) {
+            return $default ?? '';
         }
 
         return $resolvedValue;

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de">nlxShopEnvironment</label>
     <label lang="en">nlxShopEnvironment</label>
-    <version>3.3.0</version>
+    <version>3.4.0</version>
     <copyright>(c) by netlogix GmbH &amp; Co. KG</copyright>
     <license>Proprietary</license>
     <link>https://websolutions.netlogix.de/</link>
@@ -149,5 +149,9 @@
     <changelog version="3.3.0">
         <changes lang="de">Plugin Beschreibung hinzugefügt</changes>
         <changes lang="en">Added plugin description</changes>
+    </changelog>
+    <changelog version="3.4.0">
+        <changes lang="de">Environment Support mit Fallback Werten</changes>
+        <changes lang="en">Allow fallback values for env variables</changes>
     </changelog>
 </plugin>


### PR DESCRIPTION
The syntax of this feature is inspired by a8m/envsubst. Use it the following way: %env(SMTP_HOST:-localhost) When the env variable SMTP_HOST is not set we use localhost as fallback value.